### PR TITLE
added createrepo  to the startup

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -5,5 +5,6 @@ mkdir /logs/nginx
 mkdir /logs/supervisord
 
 chown nginx:nginx /logs/nginx
-
+echo "Doing initial scan"
+createrepo --update /repo
 exec /usr/bin/supervisord -n -c /etc/supervisord.conf


### PR DESCRIPTION
Added createrepo update to the startup file.  When mounting an existing
named docker data volume the xml data would not update.
