### PR TITLE
Allow PUT to deploy rpms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM golang:1.8.3 as builder
+FROM golang:1.14.1 as builder
 
 WORKDIR /go/src/github.com/dgutierrez1287/docker-yum-repo
 
@@ -19,11 +19,8 @@ LABEL maintainer="Diego Gutierrez <dgutierrez1287@gmail.com>"
 RUN yum -y install epel-release && \
     yum -y update && \
     yum -y install supervisor createrepo yum-utils nginx && \
-    yum clean all
-
-RUN mkdir /repo && \
-    chmod 777 /repo && \
-    mkdir -p /logs
+    yum clean all && \
+    mkdir -p /repo /logs
 
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY supervisord.conf /etc/supervisord.conf

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ mkdir /logs/supervisord
 
 chown nginx:nginx /logs/nginx
 
-chmod -R 0755 /repo
+chmod -R 0777 /repo
 
 if [[ "${SERVE_FILES}" == "true" ]]; then
     echo "Serving Files is on"

--- a/nginx.conf
+++ b/nginx.conf
@@ -7,19 +7,17 @@ events {
 }
 
 http {
+    server {
+        listen 80 default_server;
 
-	server {
+        location /{
+            autoindex on;
+            alias /repo/;
+            dav_methods  PUT;
+        }
+        client_max_body_size 2M;
 
-		listen 80 default_server;
-
-    	location /{
-			autoindex on;
-			alias /repo/;
-    	}
-
-		access_log /logs/nginx/access.log;
-		error_log /logs/nginx/error.log;
-
-	}
-
+        access_log /logs/nginx/access.log;
+        error_log /logs/nginx/error.log;
+    }
 }


### PR DESCRIPTION
Hello,

I wanted to use this image to upload rpms file with the curl command with the HTTP PUT method but if failled with error 405: Operation not allowed.
This PR fixes this issue. (I updated the go version for the image was not building).
Up to you if it is worth merging into the official branch.
Regards,
Laurent