### PR TITLE
Make Golang registry and version configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # build stage
-FROM golang:1.8.3 as builder
+ARG REGISTRY_PREFIX
+ARG GOLANG_VERSION=latest
+ARG CENTOS_VERSION=7
+FROM ${REGISTRY_PREFIX}golang:${GOLANG_VERSION} as builder
 
 WORKDIR /go/src/github.com/dgutierrez1287/docker-yum-repo
 
@@ -13,7 +16,8 @@ COPY src/*.go .
 RUN GOOS=linux go build -x -o repoScanner .
 
 # application image
-FROM centos:7
+ARG REGISTRY_PREFIX
+FROM ${REGISTRY_PREFIX}centos:${CENTOS_VERSION}
 LABEL maintainer="Diego Gutierrez <dgutierrez1287@gmail.com>"
 
 RUN yum -y install epel-release && \


### PR DESCRIPTION
Hello,

1- Allow to configure the Golang version
2- Give a mean to configure the registry to pull the image from. It is useful if you access docker.io registry through a cache proxy.

Regards,
Laurent